### PR TITLE
Update derive_builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 async-trait = "0.1.51"
 base64 = "0.13.0"
 consulrs_derive = { version = "0.1.0", path = "consulrs_derive" }
-derive_builder = "0.10.2"
+derive_builder = "0.11"
 http = "0.2.5"
 reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
 rustify = { version = "0.5.2", default-features = false, features = ["rustls-tls"] }


### PR DESCRIPTION
This helps avoid duplicate versions of `darling` for downstream dependencies.